### PR TITLE
Picker does not open in Maya 2026 with an opened rig

### DIFF
--- a/scripts/mansur/block/picker2/picker2.py
+++ b/scripts/mansur/block/picker2/picker2.py
@@ -749,7 +749,7 @@ class MnsPicker2(form_class, base_class):
 								visAttrNameRelated = []
 								if outModuleRoot.hasAttr(visAttrName):
 									for visSlaveCtrl in outModuleRoot.attr(visAttrName).listConnections(d = True, s = False):
-										if type(visSlaveCtrl) == pm.nodetypes.MultDoubleLinear:
+										if type(visSlaveCtrl) == (pm.nodetypes.multDL if cmds.about(v=True) >= "2026" else pm.nodetypes.MultDoubleLinear):
 											outMdlCons = visSlaveCtrl.listConnections(d = True, s = False)
 											for outMdlCon in outMdlCons:
 												visSlaveCtrlA = self.validateVisCtrl(outMdlCon)


### PR DESCRIPTION
Next line fails in Maya 2026 (C:\mansurRig\scripts\mansur\block\picker2\picker2.py, line 752)

if type(visSlaveCtrl) == pm.nodetypes.MultDoubleLinear:

```python
Traceback (most recent call last):
  File "C:\mansurRig\scripts\mansur\block\picker2\picker2.py", line 1185, in loadPicker
    mnsPicker2Win = MnsPicker2()
                    ^^^^^^^^^^^^
  File "C:\mansurRig\scripts\mansur\block\picker2\picker2.py", line 594, in __init__
    self.initializeUI()
  File "C:\mansurRig\scripts\mansur\block\picker2\picker2.py", line 628, in initializeUI
    self.setRigTop()
  File "C:\mansurRig\scripts\mansur\block\picker2\picker2.py", line 710, in setRigTop
    self.initializePuppetPicker()
  File "C:\mansurRig\scripts\mansur\block\picker2\picker2.py", line 877, in initializePuppetPicker
    self.createVisMap()
  File "C:\mansurRig\scripts\mansur\block\picker2\picker2.py", line 775, in createVisMap
    self.visRelationMapByRigTopKey[puppetName] = self.createVisRelationMapForRigTop()
                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\mansurRig\scripts\mansur\block\picker2\picker2.py", line 752, in createVisRelationMapForRigTop
    if type(visSlaveCtrl) == pm.nodetypes.MultDoubleLinear:
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\mansurRig\PythonLibs\CrossPlatform\pymel\core\nodetypes.py", line 158, in __getattr__
    raise AttributeError(name)
AttributeError: MultDoubleLinear //
```